### PR TITLE
Workaround a LibSoup error in postmarketOS 22.12

### DIFF
--- a/src/http.py
+++ b/src/http.py
@@ -18,7 +18,7 @@
 import gi
 import sys
 import enum
-gi.require_version('Soup', '2.4')
+
 from gi.repository import Soup
 
 class Priority(enum.Enum):
@@ -31,6 +31,18 @@ class Priority(enum.Enum):
     HIGH = 1
 
 _sessions = {}
+
+def Init():
+    '''
+    Init makes sure the HTTP library module is ready for use from anywhere.
+    Currently this means creating Soup sessions for every type of priority.
+
+    Make sure to call this before any other calls to libraries which would
+    want to load LibSoup.
+    '''
+    init_session(Priority.LOW)
+    init_session(Priority.NORMAL)
+    init_session(Priority.HIGH)
 
 def init_session(priority):
     global _sessions
@@ -179,3 +191,4 @@ class AsyncRequest(object):
             self._callback(status, data_stream, self._cancellable, *(self._args))
         except Exception:
             sys.excepthook(*sys.exc_info())
+

--- a/src/main.py
+++ b/src/main.py
@@ -24,11 +24,13 @@ gi.require_version('Gtk', '3.0')
 gi.require_version('Gst', '1.0')
 gi.require_version('Handy', '1')
 gi.require_version('GLib', '2.0')
+gi.require_version('Soup', '2.4')
 
 from gi.repository import Gtk, Gio, Gst, Gdk
 from euterpe_gtk.player import Player
 from euterpe_gtk.service import Euterpe
 from euterpe_gtk.widgets.window import EuterpeGtkWindow
+import euterpe_gtk.http as http
 
 import euterpe_gtk.log as log
 
@@ -39,6 +41,8 @@ class Application(Gtk.Application):
         super().__init__(application_id='com.doycho.euterpe.gtk',
                          flags=Gio.ApplicationFlags.FLAGS_NONE)
         Gst.init(None)
+        http.Init()
+
         random.seed()
         self._version = version
         self._euterpe = Euterpe(version)


### PR DESCRIPTION
It seems that there are two versions of the LibSoup getting loaded for some reason. I've found that if loading all the Soup sessions _before_ creating any soup objects for Gstreamer then this bug is not triggered.